### PR TITLE
update -tty (deprecated in swipl) to "--tty 0"

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class Engine {
         const top = path.join(__dirname, 'top.pl');
         this.swipl = spawn('swipl', [
             '-f', top,
-            '--tty 0',
+            '--no-tty',
             '-q',
             '-t', 'loop',
             '--nodebug',

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class Engine {
         const top = path.join(__dirname, 'top.pl');
         this.swipl = spawn('swipl', [
             '-f', top,
-            '-tty',
+            '--tty 0',
             '-q',
             '-t', 'loop',
             '--nodebug',


### PR DESCRIPTION
I get a warning `` `-tty` is deprecated.  Please use `--no-tty` ``

Background: 
@JanWielemaker 's removal of the old cli option seems to start here:

https://github.com/SWI-Prolog/swipl-devel/commit/0315db926ed81fefe576c639ceddcfa9a940c513#diff-41d464df24d8c5d678a8799a676c2459

There is a little more history, too.

https://github.com/SWI-Prolog/swipl-devel/commit/644b28510fb86ce4fe398abe04b4150720ba36da